### PR TITLE
Fix fga-eps-mds/2018.2-Roles#164 arrumando campos dos eventos

### DIFF
--- a/event_microservice/events/models.py
+++ b/event_microservice/events/models.py
@@ -16,24 +16,27 @@ def corret_time(value):
 
 
 class Event(models.Model):
-    ownerName = models.CharField(max_length=50)
+    ownerName = models.CharField(max_length=50, default="")
     ownerID = models.IntegerField(default=0)
-    eventName = models.CharField(max_length=50)
+    eventName = models.CharField(max_length=100)
     linkReference = models.URLField(max_length=200, default="")
     organizer = models.CharField(max_length=50)
     value = models.DecimalField(max_digits=12,
                                 decimal_places=2,
                                 validators=[not_negative],
                                 default=0.00)
-    address = models.CharField(max_length=50)
-    linkAddress = models.URLField(max_length=200, default="")
+    address = models.TextField()
+    latitude = models.IntegerField(default=0)
+    latitudeDelta = models.IntegerField(default=0)
+    longitude = models.IntegerField(default=0)
+    longitudeDelta = models.IntegerField(default=0)
     eventDate = models.DateField(auto_now=False, validators=[corret_time])
     eventHour = models.TimeField(auto_now=False)
     adultOnly = models.BooleanField(default=False)
-    eventDescription = models.TextField()
-    photo = models.URLField(default="")
-    foods = models.TextField()
-    drinks = models.TextField()
+    eventDescription = models.TextField(default="")
+    photo = models.URLField()
+    foods = models.TextField(default="")
+    drinks = models.TextField(default="")
     votes = VotableManager()
 
     class Meta:

--- a/event_microservice/events/tests.py
+++ b/event_microservice/events/tests.py
@@ -27,6 +27,7 @@ class ModelTestCase(TestCase):
         self.eventDescription = "Chato"
         self.foods = "Comidas"
         self.drinks = "Bebidas"
+        self.photo = "https://www.google.com/"
 
         self.event = Event(eventName=self.eventName,
                            ownerName=self.ownerName,
@@ -37,7 +38,8 @@ class ModelTestCase(TestCase):
                            address=self.address,
                            eventDescription=self.eventDescription,
                            foods=self.foods,
-                           drinks=self.drinks)
+                           drinks=self.drinks,
+                           photo=self.photo)
 
     def test_model_can_create_a_event(self):
         """Test the event model can create a event."""
@@ -63,7 +65,8 @@ class ViewTestCase(TestCase):
                            'address': "Here",
                            'eventDescription': "Chato",
                            'foods': "Comidas",
-                           'drinks': "Bebidas"}
+                           'drinks': "Bebidas",
+                           'photo': 'https://www.google.com/'}
         self.response1 = self.client.post(
             reverse('event-list'),
             self.event_data,
@@ -99,7 +102,8 @@ class ViewTestCase(TestCase):
                         'address': "Here",
                         'eventDescription': "Chato",
                         'foods': "Comidas",
-                        'drinks': "Bebidas"}
+                        'drinks': "Bebidas",
+                        'photo': 'https://www.google.com/'}
         response = populate_response(self, event, change_event)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -112,11 +116,12 @@ class ViewTestCase(TestCase):
                         'address': "Here",
                         'eventDescription': "Chato",
                         'foods': "Comidas",
-                        'drinks': "Bebidas"}
+                        'drinks': "Bebidas",
+                        'photo': 'https://www.google.com/'}
         response = populate_response(self, event, change_event)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-        """ Test the api cannot update if linkReference field is not a URL """
+        """ Test the api cannot update if linkReference field is not a valid URL """
         change_event = {'eventName': 'Teste',
                         'ownerName': 'Fulano',
                         'eventDate': "2099-12-18",
@@ -127,11 +132,12 @@ class ViewTestCase(TestCase):
                         'eventDescription': "Chato",
                         'foods': "Comidas",
                         'drinks': "Bebidas",
-                        'linkReference': 'incorrect.com'}
+                        'linkReference': 'incorrect.com',
+                        'photo': 'https://www.google.com/'}
         response = populate_response(self, event, change_event)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-        """ Test the api cannot update if linkReference field is not a URL """
+        """ Test the api cannot update if linkReference field is not a valid URL """
         change_event = {'eventName': 'Teste',
                         'ownerName': 'Fulano',
                         'eventDate': "2099-12-12",
@@ -142,22 +148,7 @@ class ViewTestCase(TestCase):
                         'eventDescription': "Chato",
                         'foods': "Comidas",
                         'drinks': "Bebidas",
-                        'linkAddress': 'incorrect.com'}
-        response = populate_response(self, event, change_event)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-
-        """ Test the api cannot update if file is not a image """
-        change_event = {'eventName': 'Teste',
-                        'ownerName': 'Fulano',
-                        'eventDate': "2099-12-12",
-                        'eventHour': "03:03:00",
-                        'organizer': "Fulano",
-                        'value': 0,
-                        'address': "Here",
-                        'eventDescription': "Chato",
-                        'foods': "Comidas",
-                        'drinks': "Bebidas",
-                        'photo': "teste.txt"}
+                        'photo': "google.com"}
         response = populate_response(self, event, change_event)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 


### PR DESCRIPTION
Mudança em alguns campos do evento
## Descrição
Agora alguns campos deixaram de ser obrigatórios, outros passaram a ser, e o campo de linkAdress foi trocado por latitude e longitude.

Campos obrigatórios
- [X] Nome do evento
- [X] Nome do organizador
- [X] Endereço
- [X] Data e hora
- [X] +18
- [X] Foto

Todos os outros são opcionais.

## Motivação e Contexto
Melhorar características do evento e experiência do usuário.

## Como foi testado?
Testes unitários.


## Tipo de modificações
- [X] Correção de bug
- [ ] Nova _feature_

## Lista de controle:
- [X] Meu código segue a folha de estilos implementada
- [X] Meu _commits_ segue a política de commits do repo.
- [ ] Minhas modificações requerem modificações na documentação atual.
- [ ] Atualizei a Documentação
- [X] Adicionei testes para cobrir minhas modificações.
- [X] Todos os testes foram aprovados.