### PR TITLE
Hotfix/required fields

### DIFF
--- a/event_microservice/events/models.py
+++ b/event_microservice/events/models.py
@@ -19,7 +19,6 @@ class Event(models.Model):
     ownerName = models.CharField(max_length=50, null=True)
     ownerID = models.IntegerField(null=True)
     eventName = models.CharField(max_length=100)
-    linkReference = models.URLField(max_length=200, null=True)
     organizer = models.CharField(max_length=50)
     value = models.DecimalField(max_digits=12,
                                 decimal_places=2,

--- a/event_microservice/events/models.py
+++ b/event_microservice/events/models.py
@@ -16,27 +16,27 @@ def corret_time(value):
 
 
 class Event(models.Model):
-    ownerName = models.CharField(max_length=50, default="")
-    ownerID = models.IntegerField(default=0)
+    ownerName = models.CharField(max_length=50, null=True)
+    ownerID = models.IntegerField(null=True)
     eventName = models.CharField(max_length=100)
-    linkReference = models.URLField(max_length=200, default="")
+    linkReference = models.URLField(max_length=200, null=True)
     organizer = models.CharField(max_length=50)
     value = models.DecimalField(max_digits=12,
                                 decimal_places=2,
                                 validators=[not_negative],
-                                default=0.00)
+                                null=True)
     address = models.TextField()
-    latitude = models.FloatField(default=0.0)
-    latitudeDelta = models.FloatField(default=0.0)
-    longitude = models.FloatField(default=0.0)
-    longitudeDelta = models.FloatField(default=0.0)
+    latitude = models.FloatField(null=True)
+    latitudeDelta = models.FloatField(null=True)
+    longitude = models.FloatField(null=True)
+    longitudeDelta = models.FloatField(null=True)
     eventDate = models.DateField(auto_now=False, validators=[corret_time])
     eventHour = models.TimeField(auto_now=False)
     adultOnly = models.BooleanField(default=False)
-    eventDescription = models.TextField(default="")
+    eventDescription = models.TextField(null=True)
     photo = models.URLField()
-    foods = models.TextField(default="")
-    drinks = models.TextField(default="")
+    foods = models.TextField(null=True)
+    drinks = models.TextField(null=True)
     votes = VotableManager()
 
     class Meta:

--- a/event_microservice/events/tests.py
+++ b/event_microservice/events/tests.py
@@ -121,23 +121,7 @@ class ViewTestCase(TestCase):
         response = populate_response(self, event, change_event)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-        """ Test the api cannot update if linkReference field is not a valid URL """
-        change_event = {'eventName': 'Teste',
-                        'ownerName': 'Fulano',
-                        'eventDate': "2099-12-18",
-                        'eventHour': "03:03:00",
-                        'organizer': "Fulano",
-                        'value': 0,
-                        'address': "Here",
-                        'eventDescription': "Chato",
-                        'foods': "Comidas",
-                        'drinks': "Bebidas",
-                        'linkReference': 'incorrect.com',
-                        'photo': 'https://www.google.com/'}
-        response = populate_response(self, event, change_event)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-
-        """ Test the api cannot update if linkReference field is not a valid URL """
+        """ Test the api cannot update if photo field is not a valid URL """
         change_event = {'eventName': 'Teste',
                         'ownerName': 'Fulano',
                         'eventDate': "2099-12-12",

--- a/event_microservice/votes/views.py
+++ b/event_microservice/votes/views.py
@@ -1,3 +1,0 @@
-from django.shortcuts import render
-
-# Create your views here.


### PR DESCRIPTION
Mudança nos campos que não são obrigatórios
## Descrição
O campo linkReference não tinha mais nenhuma importância para o cadastro de eventos, por isso foi removido. Outros campos opcionais agora podem ser vazios (null).

## Motivação e Contexto
Melhorar maneira que um evento é cadastrado.

## Como foi testado?
Testes unitários.


## Tipo de modificações
- [X] Correção de bug
- [ ] Nova _feature_

## Lista de controle:
- [X] Meu código segue a folha de estilos implementada
- [X] Meu _commits_ segue a política de commits do repo.
- [ ] Minhas modificações requerem modificações na documentação atual.
- [ ] Atualizei a Documentação
- [X] Adicionei testes para cobrir minhas modificações.
- [X] Todos os testes foram aprovados.